### PR TITLE
Add api keys, authorization and management

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,25 @@
 class ApplicationController < ActionController::API
+  before_action :authorize_api_key
+
+  # Check if there's a proper API key before every request
+  # This is technically susceptible to timing attacks, but I'm not concerned.
+  def authorize_api_key
+    # If it's blank, send a 403
+    if params[:api_key].blank?
+      head :forbidden
+      return
+    end
+
+    # Search for the key
+    key = ApiKey.where(key: params[:api_key])
+
+    # If there's no key, it's not authorized, 403 it
+    if key.blank?
+      head :forbidden
+      return
+    end
+
+    # Update the key wiht the current time so we know it's being used
+    key.update last_used: DateTime.now
+  end
 end

--- a/app/models/api_key.rb
+++ b/app/models/api_key.rb
@@ -1,0 +1,16 @@
+# An API key for access to the system
+# Right now the keys are stored in plaintext in the DB. We could has them, but them we could
+# also only show the users the key once, which for our limited purposes will cause a lot of
+# headaches.
+class ApiKey < ApplicationRecord
+  before_create :generate_key
+
+  def to_s
+    last_used_string = last_used.nil? ? "Never" : last_used.strftime("%FT%T")
+    "id: #{id} | name: #{name} | last_used: #{last_used_string} | key: #{key}"
+  end
+
+  def generate_key
+    self.key = SecureRandom.hex
+  end
+end

--- a/db/migrate/20200116233238_create_api_keys.rb
+++ b/db/migrate/20200116233238_create_api_keys.rb
@@ -1,0 +1,12 @@
+class CreateApiKeys < ActiveRecord::Migration[6.0]
+  def change
+    create_table :api_keys do |t|
+      t.string :key, null: false, unique: true
+      t.string :name
+      t.datetime :last_used
+      t.timestamps
+
+      t.index :key
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,0 +1,24 @@
+# This file is auto-generated from the current state of the database. Instead
+# of editing this file, please use the migrations feature of Active Record to
+# incrementally modify your database, and then regenerate this schema definition.
+#
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
+#
+# It's strongly recommended that you check this file into your version control system.
+
+ActiveRecord::Schema.define(version: 2020_01_16_233238) do
+
+  create_table "api_keys", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "name"
+    t.datetime "last_used"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["key"], name: "index_api_keys_on_key"
+  end
+
+end

--- a/lib/tasks/keys.rake
+++ b/lib/tasks/keys.rake
@@ -1,0 +1,46 @@
+# For managing API keys since we don't have a GUI
+# All generated keys have all access.
+namespace :keys do
+  desc "List all api keys"
+  task list: :environment do
+    if ApiKey.all.empty?
+      puts "No keys found"
+      exit
+    end
+
+    ApiKey.all.each do |key|
+      puts key.to_s
+    end
+  end
+
+  desc "Generate new key"
+  task :new, [:name] => :environment do |t, args|
+    if args.name.blank?
+      puts "Please supply a name for this key so you know what it's for in six months"
+      exit
+    end
+
+    key = ApiKey.create! name: args[:name]
+    puts Rainbow("New key generated ⚙️").green
+    puts Rainbow("--------------------------------------------").blue
+    puts key.to_s
+  end
+
+  desc "Delete a key"
+  task :delete, [:id] => :environment do |t, args|
+    if args.id.blank?
+      puts "You have to give an ID to actually delete"
+      exit
+    end
+
+    key = ApiKey.find(args[:id])
+
+    if key.nil?
+      puts "No key found for id #{args[:id]}"
+      exit
+    end
+
+    key.destroy!
+    puts "Successfully deleted key ##{args[:id]}"
+  end
+end

--- a/test/fixtures/api_keys.yml
+++ b/test/fixtures/api_keys.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the '{}' from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/api_key_test.rb
+++ b/test/models/api_key_test.rb
@@ -1,0 +1,7 @@
+require 'test_helper'
+
+class ApiKeyTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
We want to limit who can send a request, so we will use API keys.
Instead of having one for everyone it's basically just as easy to add
some basic multi-key management (with some very minor overhead for a db
call).

This PR adds two things:
1. A second required key for requests `api_key` a string in the JSON
object. If you don't have that you just get a 403 error, which is also
the same if you have a wrong API key.
2. Three new rake tasks to manage this they are:
    - `keys:list` List all the keys in the system
    - `keys:new[name goes here]` Create a new key with the given name
    - `keys:delete[id]` Delete a key with the given id