### PR TITLE
Add sentryio

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,6 @@ dump.rdb
 yarn-debug.log*
 .yarn-integrity
 yarn-error.log
+
+# Ignore application configuration
+/config/application.yml

--- a/Gemfile
+++ b/Gemfile
@@ -51,3 +51,10 @@ gem "grover"
 
 # Rainbow to make colors on the command line all pretty
 gem "rainbow"
+
+# Figaro helps us manage application credentials in a better way than Rails does by default
+gem "figaro"
+
+# Sentry is an error tracker for Ruby and other things
+# https://sentry.io for more info
+gem "sentry-raven"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,7 +66,11 @@ GEM
     concurrent-ruby (1.1.6)
     crass (1.0.6)
     erubi (1.9.0)
+    faraday (1.0.1)
+      multipart-post (>= 1.2, < 3)
     ffi (1.12.2)
+    figaro (1.1.1)
+      thor (~> 0.14)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
     grover (0.11.3)
@@ -93,6 +97,7 @@ GEM
     mini_portile2 (2.4.0)
     minitest (5.14.0)
     msgpack (1.3.3)
+    multipart-post (2.1.1)
     nio4r (2.5.2)
     nokogiri (1.10.9)
       mini_portile2 (~> 2.4.0)
@@ -147,7 +152,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 2.0)
     rubocop-performance (1.5.2)
       rubocop (>= 0.71.0)
-    rubocop-rails (2.5.1)
+    rubocop-rails (2.5.2)
       activesupport
       rack (>= 1.1)
       rubocop (>= 0.72.0)
@@ -160,6 +165,8 @@ GEM
     ruby-rc4 (0.1.5)
     ruby_dep (1.5.0)
     schmooze (0.2.0)
+    sentry-raven (3.0.0)
+      faraday (>= 1.0)
     spring (2.1.0)
     spring-watcher-listen (2.0.1)
       listen (>= 2.7, < 4.0)
@@ -171,7 +178,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (1.0.1)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tzinfo (1.2.7)
       thread_safe (~> 0.1)
@@ -187,6 +194,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap (>= 1.4.2)
   byebug
+  figaro
   grover
   listen (>= 3.0.5, < 3.2)
   pg
@@ -197,6 +205,7 @@ DEPENDENCIES
   rubocop-performance
   rubocop-rails
   rubocop-rails_config
+  sentry-raven
   spring
   spring-watcher-listen (~> 2.0.0)
   tzinfo-data

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ to support the entire Grover configuration surface as early as possible.
 TBD
 
 # Request Format
-TBD
+POST /convert
 ```
 {
 	"api_key": "xxxxxxxxxxxxxxxxxx",
@@ -78,6 +78,6 @@ Successfully deleted key #2
 
 TBD
 
-Note: All sample names in the documentation should be those of Celtic Bishops or saints prior to romanization of the church.
+Note: All sample names in the documentation should be those of Celtic bishops or saints prior to romanization of the church.
 In cases where no surname is known, add the city of birth or known city of origin.
 You can find some here: https://en.wikipedia.org/wiki/Celtic_Christianity

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ TBD
 
 API keys are managed through Rake tasks. This means that you must have access to the command line of the machine running Spinney. Since this is a backend-facing product that's the easiest to handle at the moment.
 
+Note: If you're using [Z shell/zsh](https://en.wikipedia.org/wiki/Z_shell), which is the default new command line on MacOS, you may need to wrap commands in `'` (single apostrophe) such as `rails 'keys:new[Dubric Ergyng]'`.
+
 ## Rake Tasks
 
 ### List

--- a/README.md
+++ b/README.md
@@ -31,4 +31,53 @@ TBD
 
 # API Key management
 
+API keys are managed through Rake tasks. This means that you must have access to the command line of the machine running Spinney. Since this is a backend-facing product that's the easiest to handle at the moment.
+
+## Rake Tasks
+
+### List
+
+List all api keys in the system
+
+###### Sample Command
+`rails keys:list`
+
+###### Sample Response
+```
+id: 1 | name: Kevin Glendalough | last_used: 2020-01-17T02:31:08 | key: 5d6daacd76019e39eb49b5a6b4ebaf7e
+id: 2 | name: Ciarán Saigir     | last_used: 2020-01-17T02:31:08 | key: 5d6daacd76019e39eb49b5a6b4ebaf7e
+```
+
+### Create
+
+Create a new api key
+
+###### Sample Command
+`rails keys:new[Elfodd Gwynedd]`
+
+###### Sample Response
+```
+New key generated ⚙️
+--------------------------------------------
+id: 2 | name: Elfodd Gwynedd | last_used: Never | key: e984ddb6e40706014acfe206bdc59c21
+```
+
+### Delete
+
+Delete an api key
+
+###### Sample Command
+`rails keys:delete[12]`
+
+###### Sample Response
+```
+Successfully deleted key #2
+```
+
+# Development
+
 TBD
+
+Note: All sample names in the documentation should be those of Celtic Bishops or saints prior to romanization of the church.
+In cases where no surname is known, add the city of birth or known city of origin.
+You can find some here: https://en.wikipedia.org/wiki/Celtic_Christianity

--- a/config/application.rb
+++ b/config/application.rb
@@ -33,5 +33,13 @@ module Spinney
     # Middleware like session, flash, cookies can be added back manually.
     # Skip views, helpers and assets when generating a new resource.
     config.api_only = true
+
+    # Don't log the api_key being sent in, since it's private
+    config.filter_parameters << :api_key
+
+    # Settings for Sentry.io
+    Raven.configure do |config|
+      config.dsn = Figaro.env.SENTRY_DSN
+    end
   end
 end

--- a/config/application.yml.sample
+++ b/config/application.yml.sample
@@ -1,0 +1,2 @@
+production:
+  SENTRY_DSN: "XXXXXXXXXXXXXXX"

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -37,7 +37,7 @@ Rails.application.configure do
   # config.action_cable.allowed_request_origins = [ 'http://example.com', /http:\/\/example.*/ ]
 
   # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
-  # config.force_ssl = true
+  config.force_ssl = true
 
   # Use the lowest log level to ensure availability of diagnostic information
   # when problems arise.

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,4 @@
+# Configure Sentry.io, specifically to remove anything we're filtering from the logs.
+Raven.configure do |config|
+  config.sanitize_fields = Rails.application.config.filter_parameters.map(&:to_s)
+end

--- a/lib/tasks/keys.rake
+++ b/lib/tasks/keys.rake
@@ -17,6 +17,7 @@ namespace :keys do
   task :new, [:name] => :environment do |t, args|
     if args.name.blank?
       puts "Please supply a name for this key so you know what it's for in six months"
+      puts "Sample: rails keys:new[Elfodd Gwynedd]"
       exit
     end
 
@@ -30,6 +31,7 @@ namespace :keys do
   task :delete, [:id] => :environment do |t, args|
     if args.id.blank?
       puts "You have to give an ID to actually delete"
+      puts "Sample: rails keys:delete[12]"
       exit
     end
 


### PR DESCRIPTION
Unfortunately we're not tracking errors, which has bit us today when
stuff started failing. To solve this in our other projects we use
Sentry.io, so we'll do the same here.

This PR does the following:
- Add Figaro gem for ENV variable management
- Adds a sample `config/application.yml.sample` file to assist in setting
  up the project. This should be copied, and renamed to
  `/config/application.yml` file and then edited for the proper purposes
- Adds the Sentry.io gem
- Adds a `/config/initializers/sentry.rb` file to set up log filtering
- Adds log filtering to `config/application.rb` so we don't log api keys
- Adds Sentry context in `app/controller/application.rb` to make sure
  relevant data is passed to Sentry for debugging
- Adds documentation for the key management rake tasks in `README.md`

This supercedes #12 
